### PR TITLE
Updated composer to use php 5.3 of array-finder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,19 @@
       "PatternLab":   "src/"
     }
   },
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/OTRD/ArrayFinder.git"
+		}
+	],	
   "require": {
-    "php": ">=5.4",
+    "php": ">=5.3",
     "alchemy/zippy": "^0.3",
     "kevinlebrun/colors.php": "^1.0",
     "michelf/php-markdown": "^1.6",
     "seld/jsonlint": "^1.0",
-    "shudrum/array-finder": "^1.0",
+    "OTRD/array-finder": "^1.1",
     "symfony/event-dispatcher": "^3.0",
     "symfony/filesystem": "^3.0",
     "symfony/finder": "^3.0",


### PR DESCRIPTION
This should be all the changes necessary to get patternlab working in 5.3. I already forked array-finder and made the changes required